### PR TITLE
Change CSSProvider to use React.Children.only

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ import { CSSProvider, toTagString, toTagComponent } from 'react-css-context';
 
 const cssMap = new Map();
 const renderOutput = ReactDOMServer.renderToString(
-  <App>
-    <CSSProvider cssMap={cssMap}>
+  <CSSProvider cssMap={cssMap}>
+    <App>
       <SomeComponent />
-    </CSSProvider>
-  </App>
+    </App>
+  </CSSProvider>
 );
 
 // use string
@@ -78,11 +78,11 @@ import { CSSProvider, getCSSMap } from 'react-css-context';
 const cssMap = getCSSMap();
 
 ReactDOM.render(
-  <App>
-    <CSSProvider cssMap={cssMap}>
+  <CSSProvider cssMap={cssMap}>
+    <App>
       <SomeComponent />
-    </CSSProvider>
-  </App>,
+    </App>
+  </CSSProvider>,
   document.getElementById('main')
 );
 ```

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "tsc --declaration",
     "lint": "tslint -p tsconfig.json",
-    "test-node": "ava ./lib/**/*.node.test.js",
-    "test-browser": "BROWSER_ENV=true ava ./lib/**/*.browser.test.js",
+    "test-node": "ava ./lib/**/*.node.test.js -v",
+    "test-browser": "BROWSER_ENV=true ava ./lib/**/*.browser.test.js -v",
     "test": "npm run build && npm run lint && npm run test-node && npm run test-browser"
   },
   "keywords": [

--- a/src/CSSProvider.tsx
+++ b/src/CSSProvider.tsx
@@ -80,7 +80,7 @@ export class CSSProvider extends React.Component<CSSProviderProps, CSSContext> {
   public render() {
     return (
       <Provider value={this.state}>
-        {this.props.children}
+        {React.Children.only(this.props.children)}
       </Provider>
     );
   }

--- a/src/index.browser.test.tsx
+++ b/src/index.browser.test.tsx
@@ -64,8 +64,8 @@ test('Client Side Rendering', (t) => {
 
   document.body.innerHTML = '<div id="main"></div>';
   render(
-    <App>
-      <CSSProvider cssMap={cssMap}>
+    <CSSProvider cssMap={cssMap}>
+      <App>
         <div id="test_1">
           <CSSCollector hrefs={[CSS_FILE_1]}>
             ok
@@ -81,8 +81,8 @@ test('Client Side Rendering', (t) => {
             ok
           </CSSCollector2>
         </div>
-      </CSSProvider>
-    </App>,
+      </App>
+    </CSSProvider>,
     document.getElementById('main'),
   );
 

--- a/src/index.node.test.tsx
+++ b/src/index.node.test.tsx
@@ -31,16 +31,16 @@ test('Server Side Rendering', async (t) => {
   const cssMap = new Map();
 
   const readableStream = renderToStaticNodeStream(
-    <App>
-      <CSSProvider cssMap={cssMap}>
+    <CSSProvider cssMap={cssMap}>
+      <App>
         <CSSCollector hrefs={[CSS_FILE_1, CSS_FILE_2]}>
           ok
         </CSSCollector>
         <CSSCollector hrefs={[CSS_FILE_3]}>
           <p>good</p>
         </CSSCollector>
-      </CSSProvider>
-    </App>,
+      </App>
+    </CSSProvider>,
   );
 
   const result = readableStream.read().toString();
@@ -56,4 +56,27 @@ test('Server Side Rendering', async (t) => {
   const cssTagComponentString = renderToStaticMarkup(cssTagComponent);
 
   t.is(cssTagString, cssTagComponentString);
+});
+
+test('CSSProvider can only receive single element.', (t) => {
+
+  try {
+    const cssMap = new Map();
+    renderToStaticMarkup(
+      <CSSProvider cssMap={cssMap}>
+        <App>
+          <CSSCollector hrefs={[CSS_FILE_1, CSS_FILE_2]}>
+            ok
+          </CSSCollector>
+          <CSSCollector hrefs={[CSS_FILE_3]}>
+            <p>good</p>
+          </CSSCollector>
+        </App>
+        <App />
+      </CSSProvider>,
+    );
+    t.fail();
+  } catch (e) {
+    t.pass();
+  }
 });


### PR DESCRIPTION
**Destructive change**

To use as root component, CSSProvider’s children have to be an single ReactElement.